### PR TITLE
Update demo.py

### DIFF
--- a/f3/demo.py
+++ b/f3/demo.py
@@ -40,11 +40,11 @@ def nested_dict_update(base_dict, update_dict, create_missing=False):
 # Ask Copilot: "Explain this class and its methods"
 class User:
     def __init__(self, user_id, name, email, status, level):
-        self.user_id = user_id
-        self.name = name
-        self.email = email
-        self.status = status
-        self.level = level
+        elf.user_id = user_id
+       elf.name = name
+        elf.email = email
+        elf.status = status
+        elf.level = level
 
     def is_active(self):
         return self.status == "active"


### PR DESCRIPTION
This pull request introduces a typo in the `User` class constructor, where the `self` keyword was mistakenly replaced with `elf`. This issue could lead to runtime errors when creating instances of the `User` class.

Key change:

* [`f3/demo.py`](diffhunk://#diff-d2f40ac0f6c21b30e6663f96634ca795eb0cdbfcecf42bd977bdc994395dfe3bL43-R47): In the `User` class `__init__` method, the `self` keyword was incorrectly replaced with `elf` for all instance variable assignments (`user_id`, `name`, `email`, `status`, and `level`).